### PR TITLE
Update Login.vue to fix the dismissError() method

### DIFF
--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -47,7 +47,7 @@ export default {
   methods: {
     dismissError () {
       this.error = undefined
-      this.clearAuthenticationError()
+      this.clearAuthenticateError()
     },
 
     onSubmit (email, password) {
@@ -64,7 +64,7 @@ export default {
         })
     },
     ...mapMutations('auth', {
-      clearAuthenticationError: 'clearAuthenticationError'
+      clearAuthenticateError: 'clearAuthenticateError'
     }),
     ...mapActions('auth', ['authenticate'])
   }


### PR DESCRIPTION
Minor bug fix: Changed "clearAuthenticationError" to "clearAuthenticateError" as that's the name of the mutation in the Feathers-Vuex  Auth module.