### PR TITLE
Fix :key attribute in message list rendering

### DIFF
--- a/src/components/Chat/Messages.vue
+++ b/src/components/Chat/Messages.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-column col col-9">
     <main class="chat flex flex-column flex-1 clear">
-      <single-message v-for="message in messages" key="message._id" :message="message" v-cloak />
+      <single-message v-for="message in messages" :key="message._id" :message="message" v-cloak />
     </main>
     <ComposeMessage :createMessage="createMessage" />
   </div>


### PR DESCRIPTION
As message rendering is pretty simple here, the app seems to work fine without the fix, but will generate errors.